### PR TITLE
Switch to /api from /graphql for k8s ingress paths

### DIFF
--- a/deployment/inventory.yaml
+++ b/deployment/inventory.yaml
@@ -16,7 +16,7 @@ all:
           k8s_container_port: 8000
           k8s_container_ingress_paths:
           - /admin
-          - /graphql
+          - /api
           - /django-static
           vault_database_password: !vault |
             $ANSIBLE_VAULT;1.1;AES256


### PR DESCRIPTION
This should make /api work on the server.