### PR TITLE
[RATOM-76] did it

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@
 # version of Django within the given range, but not for versions outside that
 # range. So if 1.11.12 gets released, we get warned. If 2.0.1 gets released,
 # we don't.
-Django==2.2.8  # rq.filter: >=2.2.7,<2.3
+Django==2.2.10  # rq.filter: >=2.2.10,<2.3
 # Required by Django
 sqlparse==0.3.0
 pytz


### PR DESCRIPTION
passes super basic smoke test locally
Got a warning from github about django vulnerability when I upgraded, but I'm guessing that they just haven't updated their system to include 2.2.10 as safe. The warning referred to the account takeover bug that used unicode email addresses that was fixed in 2.2.8.