### PR TITLE
Restore Elasticsearch logging functionality

### DIFF
--- a/api/views/message.py
+++ b/api/views/message.py
@@ -3,19 +3,17 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from django.conf import settings
 from django_elasticsearch_dsl_drf import constants, filter_backends
-from django_elasticsearch_dsl_drf.viewsets import DocumentViewSet
 from django_elasticsearch_dsl_drf.pagination import LimitOffsetPagination
 from elasticsearch_dsl import DateHistogramFacet, TermsFacet
 
 from api.documents.message import MessageDocument
-from api.documents.utils import LoggingPageNumberPagination
 from core.models import Message
 from api.serializers import (
     MessageSerializer,
     MessageDocumentSerializer,
 )
+from api.views.utils import LoggingDocumentViewSet
 
 __all__ = ("message_detail", "MessageDocumentView")
 
@@ -44,7 +42,7 @@ HIGHLIGHT_LABELS = {
 }
 
 
-class MessageDocumentView(DocumentViewSet):
+class MessageDocumentView(LoggingDocumentViewSet):
     """The MessageDocument view."""
 
     permission_classes = (IsAuthenticated,)
@@ -61,8 +59,6 @@ class MessageDocumentView(DocumentViewSet):
         filter_backends.FacetedSearchFilterBackend,
         filter_backends.HighlightBackend,
     ]
-    if settings.ELASTICSEARCH_LOG_QUERIES:
-        pagination_class = LoggingPageNumberPagination
 
     # Define search fields
     search_fields = (

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -1,0 +1,13 @@
+from django_elasticsearch_dsl_drf.viewsets import DocumentViewSet
+
+from api.documents.utils import LoggingSearch
+
+
+class LoggingDocumentViewSet(DocumentViewSet):
+    """DocumentViewSet extension that instantiates LoggingSearch to perform optional logging."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.search = LoggingSearch(
+            using=self.client, index=self.index, doc_type=self.document._doc_type.name
+        )

--- a/deployment/host_vars/caktus-ratom.yml
+++ b/deployment/host_vars/caktus-ratom.yml
@@ -58,3 +58,4 @@ k8s_environment_variables:
   AZURE_URL: "ratomstaging.blob.core.windows.net"
   AZURE_CONTAINER: "a-public-container"
   RATOM_SAMPLE_DATA_ENABLED: "true"
+  ELASTICSEARCH_LOG_QUERIES: "true"


### PR DESCRIPTION
Optionally log full ES query regardless of pagination class.