### PR TITLE
[RATOM-137] Adds two new search backends

### DIFF
--- a/api/documents/message.py
+++ b/api/documents/message.py
@@ -19,7 +19,7 @@ class MessageDocument(Document):
     """Message Elasticsearch Document"""
 
     id = fields.IntegerField(attr="id")
-    source_id = fields.TextField()
+    source_id = fields.TextField(fielddata=True)
     msg_from = fields.TextField()
     msg_to = fields.TextField()
     subject = fields.TextField()

--- a/api/views/message.py
+++ b/api/views/message.py
@@ -81,16 +81,13 @@ class MessageDocumentView(LoggingDocumentViewSet):
     # )
 
     multi_match_search_fields = {
-        "subject": {"boost": 4},
-        "body": {"boost": 2},
+        "subject": None,
+        "body": None,
     }
 
     multi_match_options = {"type": "phrase"}
 
-    simple_query_string_search_fields = {
-        "subject": {"boost": 4},
-        "body": {"boost": 2},
-    }
+    simple_query_string_search_fields = {"subject": None, "body": None}
 
     simple_query_string_options = {
         "default_operator": "and",

--- a/api/views/message.py
+++ b/api/views/message.py
@@ -68,15 +68,33 @@ class MessageDocumentView(LoggingDocumentViewSet):
         filter_backends.CompoundSearchFilterBackend,
         filter_backends.FacetedSearchFilterBackend,
         filter_backends.HighlightBackend,
+        filter_backends.MultiMatchSearchFilterBackend,
+        filter_backends.SimpleQueryStringSearchFilterBackend,
     ]
 
     # Define search fields
-    search_fields = (
-        "msg_from",
-        "msg_to",
-        "subject",
-        "body",
-    )
+    # search_fields = (
+    #     "msg_from",
+    #     "msg_to",
+    #     "subject",
+    #     "body",
+    # )
+
+    multi_match_search_fields = {
+        "subject": {"boost": 4},
+        "body": {"boost": 2},
+    }
+
+    multi_match_options = {"type": "phrase"}
+
+    simple_query_string_search_fields = {
+        "subject": {"boost": 4},
+        "body": {"boost": 2},
+    }
+
+    simple_query_string_options = {
+        "default_operator": "and",
+    }
 
     faceted_search_fields = {
         "processed": {
@@ -119,11 +137,13 @@ class MessageDocumentView(LoggingDocumentViewSet):
     highlight_fields = {
         "body": {"enabled": True, "options": HIGHLIGHT_LABELS},
         "subject": {"enabled": True, "options": HIGHLIGHT_LABELS},
-        "msg_to": {"options": HIGHLIGHT_LABELS},
-        "msg_from": {"options": HIGHLIGHT_LABELS},
     }
 
     # Define ordering fields
-    ordering_fields = {"_score": "_score", "sent_date": "sent_date"}
+    ordering_fields = {
+        "_score": "_score",
+        "sent_date": "sent_date",
+        "source_id": "source_id",
+    }
     # Specify default ordering
-    ordering = ("-_score", "sent_date")
+    ordering = ("-_score", "sent_date", "source_id")


### PR DESCRIPTION
Adds `multi_match` and `simple_query_string` as backends to the viewset. This fixes the ANDing problem.

This PR also adds `source_id` as a ordering field to fix ordering when email messages are for all other fields identical.