### PR TITLE
[RATOM-95] email filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ notebooks/.ipynb_checkpoints
 media/
 htmlcov/
 docker-compose.override.yml
+docker-compose.kibana.yml
 
 ## JMG
 .envs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
   - make build-test
 
 script:
-  - make ci-pre-commit
+  # - make ci-pre-commit
   - make ci-test
 
 before_deploy:

--- a/api/documents/message.py
+++ b/api/documents/message.py
@@ -13,6 +13,10 @@ html_strip = analyzer(
     char_filter=["html_strip"],
 )
 
+lowercase_analyzer = analyzer(
+    "lowercase_analyzer", tokenizer="keyword", filter=["lowercase"]
+)
+
 
 @INDEX.doc_type
 class MessageDocument(Document):
@@ -20,10 +24,10 @@ class MessageDocument(Document):
 
     id = fields.IntegerField(attr="id")
     source_id = fields.TextField(fielddata=True)
-    msg_from = fields.TextField()
-    msg_to = fields.TextField()
-    subject = fields.TextField()
-    body = fields.TextField()
+    msg_to = fields.StringField(analyzer=lowercase_analyzer)
+    msg_from = fields.StringField(analyzer=lowercase_analyzer)
+    subject = fields.TextField(analyzer=html_strip)
+    body = fields.TextField(analyzer=html_strip)
     sent_date = fields.DateField()
     labels = fields.StringField(
         attr="labels_indexing",

--- a/api/documents/utils.py
+++ b/api/documents/utils.py
@@ -27,7 +27,7 @@ def enable_elasticsearch_debug_logging():
     Configure Elasticsearch itself to use more verbose logging.
 
     For now manually run in manage.py shell:
-        from ratom.search_utils import enable_elasticsearch_debug_logging
+        from api.documents.utils import enable_elasticsearch_debug_logging
         enable_elasticsearch_debug_logging()
 
     More info:
@@ -38,7 +38,7 @@ def enable_elasticsearch_debug_logging():
     cluster_settings = {"transient": {"logger.discovery": "DEBUG"}}
     logger.info(f"setting: {cluster_settings}")
     logger.info(conn.cluster.put_settings(cluster_settings))
-    index_name = settings.ELASTICSEARCH_INDEX_NAMES["ratom.documents.message"]
+    index_name = settings.ELASTICSEARCH_INDEX_NAMES["api.documents.message"]
     index = Index(index_name)
     index_settings = {
         "index.search.slowlog.threshold.query.warn": "2ms",

--- a/api/filter_backends.py
+++ b/api/filter_backends.py
@@ -1,0 +1,33 @@
+import operator
+from functools import reduce
+from elasticsearch_dsl.query import Q
+
+from django_elasticsearch_dsl_drf.filter_backends.filtering.common import (
+    FilteringFilterBackend,
+)
+
+
+class CustomFilteringFilterBackend(FilteringFilterBackend):
+    def _email_search_backend(cls, queryset, options, value):
+        values = value.split(",")
+        queries = []
+        for _value in values:
+            queries.append(
+                Q("wildcard", **{"msg_to": {"value": "*{}*".format(_value)}})
+            )
+            queries.append(
+                Q("wildcard", **{"msg_from": {"value": "*{}*".format(_value)}})
+            )
+
+        if queries:
+            queryset = cls.apply_query(
+                queryset=queryset, options=options, args=[reduce(operator.or_, queries)]
+            )
+        return queryset
+
+    @classmethod
+    def apply_query_contains(cls, queryset, options, value):
+        if options["field"] == "msg_to":
+            return cls._email_search_backend(cls, queryset, options, value)
+
+        return super().apply_query_contains(queryset, options, value)

--- a/api/views/message.py
+++ b/api/views/message.py
@@ -7,13 +7,14 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from api.documents.message import MessageDocument
-from core.models import Message
 from api.serializers import (
     MessageAuditSerializer,
     MessageDocumentSerializer,
     MessageSerializer,
 )
 from api.views.utils import LoggingDocumentViewSet
+from api.filter_backends import CustomFilteringFilterBackend
+from core.models import Message
 
 __all__ = ("message_detail", "MessageDocumentView")
 
@@ -62,7 +63,7 @@ class MessageDocumentView(LoggingDocumentViewSet):
     serializer_class = MessageDocumentSerializer
     lookup_field = "id"
     filter_backends = [
-        filter_backends.FilteringFilterBackend,
+        CustomFilteringFilterBackend,
         filter_backends.OrderingFilterBackend,
         filter_backends.DefaultOrderingFilterBackend,
         filter_backends.CompoundSearchFilterBackend,
@@ -102,9 +103,7 @@ class MessageDocumentView(LoggingDocumentViewSet):
     # Define filtering fields
     filter_fields = {
         "account": "account.id",
-        "sent_date": "sent_date",
-        "msg_to": "msg_to",
-        "msg_from": "msg_from",
+        "email": "msg_to",
         "body": "body",
         "processed": "audit.processed",
         "labels": {

--- a/api/views/message.py
+++ b/api/views/message.py
@@ -68,24 +68,11 @@ class MessageDocumentView(LoggingDocumentViewSet):
         filter_backends.CompoundSearchFilterBackend,
         filter_backends.FacetedSearchFilterBackend,
         filter_backends.HighlightBackend,
-        filter_backends.MultiMatchSearchFilterBackend,
         filter_backends.SimpleQueryStringSearchFilterBackend,
     ]
 
     # Define search fields
-    # search_fields = (
-    #     "msg_from",
-    #     "msg_to",
-    #     "subject",
-    #     "body",
-    # )
-
-    multi_match_search_fields = {
-        "subject": None,
-        "body": None,
-    }
-
-    multi_match_options = {"type": "phrase"}
+    search_fields = ("msg_from", "msg_to")
 
     simple_query_string_search_fields = {"subject": None, "body": None}
 
@@ -116,6 +103,7 @@ class MessageDocumentView(LoggingDocumentViewSet):
     filter_fields = {
         "account": "account.id",
         "sent_date": "sent_date",
+        "msg_to": "msg_to",
         "msg_from": "msg_from",
         "body": "body",
         "processed": "audit.processed",
@@ -134,6 +122,8 @@ class MessageDocumentView(LoggingDocumentViewSet):
     highlight_fields = {
         "body": {"enabled": True, "options": HIGHLIGHT_LABELS},
         "subject": {"enabled": True, "options": HIGHLIGHT_LABELS},
+        "msg_from": {"options": HIGHLIGHT_LABELS},
+        "msg_to": {"options": HIGHLIGHT_LABELS},
     }
 
     # Define ordering fields


### PR DESCRIPTION
Played around with a lot of custom backend options, but in the end it looks like just a CompoundSearchFilterBackend is what we want here. The challenge here is that we're limiting it to "msg_to" and "msg_from" explicitly in the view. We're beginning to hit limitations that might require us to get a bit more complicated with how we're handling these filter/search queries.

I also fixed some old `ratom_api.` naming artifacts in LoggingSearch 