### PR TITLE
[RATOM-169] Removes authentication. This is only available in dev anyway

### DIFF
--- a/api/views/sample_data.py
+++ b/api/views/sample_data.py
@@ -1,7 +1,6 @@
 from django.db import transaction
 
-from rest_framework.permissions import IsAuthenticated
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
 from api.sample_data.data import sample_reset_all
@@ -9,7 +8,6 @@ from api.sample_data.data import sample_reset_all
 __all__ = ("reset_sample_data",)
 
 
-@permission_classes([IsAuthenticated])
 @api_view(["POST"])
 @transaction.atomic
 def reset_sample_data(request):


### PR DESCRIPTION
Removes authentication from this view. This view is only accessible in dev anyway so it's not necessary for security, but very necessary to jumpstart cypress tests.