### PR TITLE
[RATOM-87] NLP Labels: Display on messages

### DIFF
--- a/api/documents/message.py
+++ b/api/documents/message.py
@@ -29,13 +29,19 @@ class MessageDocument(Document):
     subject = fields.TextField(analyzer=html_strip)
     body = fields.TextField(analyzer=html_strip)
     sent_date = fields.DateField()
-    labels = fields.StringField(
+    labels = fields.NestedField(
         attr="labels_indexing",
-        fields={
-            "raw": fields.KeywordField(multi=True),
-            "suggest": fields.CompletionField(multi=True),
-        },
-        multi=True,
+        properties={
+            "importer": fields.NestedField(
+                properties={"name": fields.StringField()}, multi=True
+            ),
+        }
+        # attr="labels_indexing",
+        # fields={
+        #     "raw": fields.KeywordField(multi=True),
+        #     "suggest": fields.CompletionField(multi=True),
+        # },
+        # multi=True,
     )
 
     audit = fields.ObjectField(

--- a/api/documents/message.py
+++ b/api/documents/message.py
@@ -29,14 +29,6 @@ class MessageDocument(Document):
     subject = fields.TextField(analyzer=html_strip)
     body = fields.TextField(analyzer=html_strip)
     sent_date = fields.DateField()
-    labels = fields.NestedField(
-        attr="labels_indexing",
-        properties={
-            "type": fields.StringField(fields={"raw": fields.KeywordField()}),
-            "name": fields.StringField(fields={"raw": fields.KeywordField()}),
-        },
-        multi=True,
-    )
 
     audit = fields.ObjectField(
         properties={

--- a/api/documents/message.py
+++ b/api/documents/message.py
@@ -32,16 +32,10 @@ class MessageDocument(Document):
     labels = fields.NestedField(
         attr="labels_indexing",
         properties={
-            "importer": fields.NestedField(
-                properties={"name": fields.StringField()}, multi=True
-            ),
-        }
-        # attr="labels_indexing",
-        # fields={
-        #     "raw": fields.KeywordField(multi=True),
-        #     "suggest": fields.CompletionField(multi=True),
-        # },
-        # multi=True,
+            "importer": fields.StringField(
+                fields={"raw": fields.KeywordField(multi=True)}, multi=True
+            )
+        },
     )
 
     audit = fields.ObjectField(

--- a/api/documents/message.py
+++ b/api/documents/message.py
@@ -32,10 +32,10 @@ class MessageDocument(Document):
     labels = fields.NestedField(
         attr="labels_indexing",
         properties={
-            "importer": fields.StringField(
-                fields={"raw": fields.KeywordField(multi=True)}, multi=True
-            )
+            "type": fields.StringField(fields={"raw": fields.KeywordField()}),
+            "name": fields.StringField(fields={"raw": fields.KeywordField()}),
         },
+        multi=True,
     )
 
     audit = fields.ObjectField(
@@ -44,6 +44,13 @@ class MessageDocument(Document):
             "is_record": fields.BooleanField(),
             "is_restricted": fields.BooleanField(),
             "needs_redaction": fields.BooleanField(),
+            "labels": fields.NestedField(
+                properties={
+                    "type": fields.StringField(fields={"raw": fields.KeywordField()}),
+                    "name": fields.StringField(fields={"raw": fields.KeywordField()}),
+                },
+                multi=True,
+            ),
         }
     )
 

--- a/api/sample_data/data.py
+++ b/api/sample_data/data.py
@@ -2,6 +2,7 @@ import logging
 
 from api.sample_data.etl import load_data
 from core.models import Account, MessageAudit, File
+from etl.message.nlp import extract_labels, load_nlp_model
 
 SAMPLE_DATA_SETS = (
     {
@@ -20,11 +21,12 @@ logger = logging.getLogger(__name__)
 
 def sample_reset_all():
     """Reset all sample datasets."""
+    spacy_model = load_nlp_model()
     for dataset in SAMPLE_DATA_SETS:
-        reset_dataset(**dataset)
+        reset_dataset(**dataset, spacy_model=spacy_model)
 
 
-def reset_dataset(title, files, source):
+def reset_dataset(title, files, source, spacy_model):
     """Reset specified sample data."""
     logger.info(f"Resetting sample dataset: {title}")
     account, _ = Account.objects.get_or_create(title=title)
@@ -38,7 +40,11 @@ def reset_dataset(title, files, source):
         for message in messages:
             message.object.account = account
             message.object.file = ratom_file
+            labels = extract_labels(
+                f"{message.object.subject}\n{message.object.body}", spacy_model
+            )
             message.object.audit = MessageAudit.objects.create()
+            message.object.audit.labels.add(*labels)
             message.object.save()
         ratom_file.reported_total_messages = ratom_file.message_set.count()
         ratom_file.import_status = File.COMPLETE

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -160,17 +160,10 @@ class MessageDocumentSerializer(serializers.Serializer):
     subject = serializers.CharField(read_only=True)
     body = serializers.CharField(read_only=True)
     directory = serializers.CharField(read_only=True)
-    labels = serializers.SerializerMethodField()
     highlight = serializers.SerializerMethodField()
     score = serializers.SerializerMethodField()
     processed = serializers.SerializerMethodField(method_name="get_processed")
     audit = serializers.SerializerMethodField()
-
-    def get_labels(self, obj):
-        """Get labels."""
-        if obj.labels:
-            return obj.labels
-        return {}
 
     def get_highlight(self, obj):
         if hasattr(obj.meta, "highlight"):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -169,7 +169,7 @@ class MessageDocumentSerializer(serializers.Serializer):
     def get_labels(self, obj):
         """Get labels."""
         if obj.labels:
-            return obj_to_dict(obj.labels)["_d_"]
+            return obj.labels
         return {}
 
     def get_highlight(self, obj):
@@ -181,7 +181,6 @@ class MessageDocumentSerializer(serializers.Serializer):
         return obj.meta.score
 
     def get_processed(self, obj):
-        logger.info(obj.__repr__())
         if obj.audit:
             return obj.audit.processed
         return False

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -78,7 +78,7 @@ class AccountSerializer(serializers.ModelSerializer):
 
 
 class MessageAuditSerializer(serializers.ModelSerializer):
-    # labels = serializers.SerializerMethodField()
+    labels = serializers.SerializerMethodField()
 
     def validate(self, data):
         is_record = data.get("is_record")
@@ -108,8 +108,8 @@ class MessageAuditSerializer(serializers.ModelSerializer):
         instance.save()
         return instance
 
-    # def labels(self, obj):
-    #     return obj.audit.labels_indexing
+    def get_labels(self, obj):
+        return obj.labels_indexing
 
     class Meta:
         model = MessageAudit
@@ -121,7 +121,7 @@ class MessageAuditSerializer(serializers.ModelSerializer):
             "needs_redaction",
             "restricted_until",
             "updated_by",
-            # "labels",
+            "labels",
         ]
         read_only_fields = ["processed", "date_processed", "updated_by"]
 
@@ -164,7 +164,7 @@ class MessageDocumentSerializer(serializers.Serializer):
     highlight = serializers.SerializerMethodField()
     score = serializers.SerializerMethodField()
     processed = serializers.SerializerMethodField(method_name="get_processed")
-    audit = MessageAuditSerializer(read_only=True)
+    audit = serializers.SerializerMethodField()
 
     def get_labels(self, obj):
         """Get labels."""
@@ -187,7 +187,7 @@ class MessageDocumentSerializer(serializers.Serializer):
         return False
 
     def get_audit(self, obj):
-        return obj.audit
+        return obj_to_dict(obj.audit)["_d_"]
 
     class Meta(object):
         document = MessageDocument

--- a/api/tests/search/conftest.py
+++ b/api/tests/search/conftest.py
@@ -1,0 +1,45 @@
+import pytest
+
+from django.urls import reverse
+
+from core.tests import factories
+
+
+@pytest.fixture
+def url():
+    yield reverse("search_messages")
+
+
+@pytest.fixture
+def account_eric():
+    yield factories.AccountFactory()
+
+
+@pytest.fixture
+def account_sally():
+    yield factories.AccountFactory()
+
+
+@pytest.fixture
+def file_eric(account_eric):
+    yield factories.FileFactory(account=account_eric)
+
+
+@pytest.fixture
+def file_sally(account_sally):
+    yield factories.FileFactory(account=account_sally)
+
+
+@pytest.fixture
+def message_eric1(file_eric):
+    yield factories.MessageFactory(account=file_eric.account, file=file_eric)
+
+
+@pytest.fixture
+def message_sally1(file_eric):
+    yield factories.MessageFactory(account=file_sally.account, file=file_sally)
+
+
+@pytest.fixture
+def message_sally2(file_eric):
+    yield factories.MessageFactory(account=file_sally.account, file=file_sally)

--- a/api/tests/search/conftest.py
+++ b/api/tests/search/conftest.py
@@ -8,12 +8,18 @@ from core.tests import factories
 
 
 @pytest.fixture(scope="function", autouse=True)
-def elasticsearch():
+def elasticsearch(request):
     registry.register_document(MessageDocument)
-    for index in registry.get_indices():
-        index.delete(ignore=404)
+
+    def delete_indices():
+        for index in registry.get_indices():
+            index.delete(ignore=404)
+
+    delete_indices()
     for index in registry.get_indices():
         index.create()
+    # always clean up indicies at end of scoped context
+    request.addfinalizer(delete_indices)
 
 
 @pytest.fixture

--- a/api/tests/search/conftest.py
+++ b/api/tests/search/conftest.py
@@ -1,8 +1,19 @@
 import pytest
 
 from django.urls import reverse
+from django_elasticsearch_dsl.registries import registry
 
+from api.documents.message import MessageDocument
 from core.tests import factories
+
+
+@pytest.fixture(scope="function", autouse=True)
+def elasticsearch():
+    registry.register_document(MessageDocument)
+    for index in registry.get_indices():
+        index.delete(ignore=404)
+    for index in registry.get_indices():
+        index.create()
 
 
 @pytest.fixture

--- a/api/tests/search/conftest.py
+++ b/api/tests/search/conftest.py
@@ -57,6 +57,11 @@ def sally2(file_sally):
 
 
 @pytest.fixture
+def sally3(file_sally):
+    return factories.MessageFactory(account=file_sally.account, file=file_sally)
+
+
+@pytest.fixture
 def event():
     return factories.LabelFactory(name="EVENT")
 
@@ -64,3 +69,8 @@ def event():
 @pytest.fixture
 def org():
     return factories.LabelFactory(name="ORG")
+
+
+@pytest.fixture
+def date():
+    return factories.LabelFactory(name="DATE")

--- a/api/tests/search/conftest.py
+++ b/api/tests/search/conftest.py
@@ -7,39 +7,49 @@ from core.tests import factories
 
 @pytest.fixture
 def url():
-    yield reverse("search_messages")
+    return reverse("search_messages")
 
 
 @pytest.fixture
 def account_eric():
-    yield factories.AccountFactory()
+    return factories.AccountFactory()
 
 
 @pytest.fixture
 def account_sally():
-    yield factories.AccountFactory()
+    return factories.AccountFactory()
 
 
 @pytest.fixture
 def file_eric(account_eric):
-    yield factories.FileFactory(account=account_eric)
+    return factories.FileFactory(account=account_eric)
 
 
 @pytest.fixture
 def file_sally(account_sally):
-    yield factories.FileFactory(account=account_sally)
+    return factories.FileFactory(account=account_sally)
 
 
 @pytest.fixture
-def message_eric1(file_eric):
-    yield factories.MessageFactory(account=file_eric.account, file=file_eric)
+def eric1(file_eric):
+    return factories.MessageFactory(account=file_eric.account, file=file_eric)
 
 
 @pytest.fixture
-def message_sally1(file_eric):
-    yield factories.MessageFactory(account=file_sally.account, file=file_sally)
+def sally1(file_sally):
+    return factories.MessageFactory(account=file_sally.account, file=file_sally)
 
 
 @pytest.fixture
-def message_sally2(file_eric):
-    yield factories.MessageFactory(account=file_sally.account, file=file_sally)
+def sally2(file_sally):
+    return factories.MessageFactory(account=file_sally.account, file=file_sally)
+
+
+@pytest.fixture
+def event():
+    return factories.LabelFactory(name="EVENT")
+
+
+@pytest.fixture
+def org():
+    return factories.LabelFactory(name="ORG")

--- a/api/tests/search/test_search.py
+++ b/api/tests/search/test_search.py
@@ -1,20 +1,6 @@
 import pytest
 
-from django_elasticsearch_dsl.registries import registry
-
-from api.documents.message import MessageDocument
-
-
 pytestmark = pytest.mark.django_db
-
-
-@pytest.fixture
-def elasticsearch(autouse=True):
-    registry.register_document(MessageDocument)
-    for index in registry.get_indices():
-        index.delete(ignore=404)
-    for index in registry.get_indices():
-        index.create()
 
 
 def test_account_message_in_results(url, api_client, ratom_message):
@@ -27,8 +13,18 @@ def test_account_does_not_exist(url, api_client, ratom_message):
     assert not response.data["results"]
 
 
-def test_label_search(url, api_client, sally1, event):
+def test_label_match_single_term(url, api_client, sally1, event):
     sally1.audit.labels.add(event)
     sally1.save()
     response = api_client.get(url, data={"labels_importer": event.name})
     assert event.name in response.data["results"][0]["labels"]["importer"]
+
+
+def test_label_match_exclude_others(url, api_client, sally1, sally2, event, org):
+    sally1.audit.labels.add(event)
+    sally1.save()
+    sally2.audit.labels.add(org)
+    sally2.save()
+    response = api_client.get(url, data={"labels_importer": event.name})
+    assert event.name in response.data["results"][0]["labels"]["importer"]
+    assert org.name not in response.data["results"][0]["labels"]["importer"]

--- a/api/tests/search/test_search.py
+++ b/api/tests/search/test_search.py
@@ -17,11 +17,18 @@ def elasticsearch(autouse=True):
         index.create()
 
 
-def test_empty_search_returns_results(url, api_client, ratom_message):
+def test_account_message_in_results(url, api_client, ratom_message):
     response = api_client.get(url, data={"account": ratom_message.account.pk})
     assert response.data["results"][0]["id"] == ratom_message.pk
 
 
-def test_search_account_does_not_exist(url, api_client, ratom_message):
+def test_account_does_not_exist(url, api_client, ratom_message):
     response = api_client.get(url, data={"account": 1000})
-    assert len(response.data["results"]) == 0
+    assert not response.data["results"]
+
+
+def test_label_search(url, api_client, sally1, event):
+    sally1.audit.labels.add(event)
+    sally1.save()
+    response = api_client.get(url, data={"labels_importer": event.name})
+    assert event.name in response.data["results"][0]["labels"]["importer"]

--- a/api/tests/search/test_search.py
+++ b/api/tests/search/test_search.py
@@ -1,6 +1,13 @@
+import os
 import pytest
 
-pytestmark = pytest.mark.django_db
+pytestmark = [
+    pytest.mark.skipif(
+        os.getenv("TEST_ELASTICSEARCH", "false") == "false",
+        reason="TEST_ELASTICSEARCH is not set to 'true'",
+    ),
+    pytest.mark.django_db,
+]
 
 
 def test_account_message_in_results(url, api_client, ratom_message):

--- a/api/tests/search/test_search.py
+++ b/api/tests/search/test_search.py
@@ -1,0 +1,27 @@
+import pytest
+
+from django_elasticsearch_dsl.registries import registry
+
+from api.documents.message import MessageDocument
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def elasticsearch(autouse=True):
+    registry.register_document(MessageDocument)
+    for index in registry.get_indices():
+        index.delete(ignore=404)
+    for index in registry.get_indices():
+        index.create()
+
+
+def test_empty_search_returns_results(url, api_client, ratom_message):
+    response = api_client.get(url, data={"account": ratom_message.account.pk})
+    assert response.data["results"][0]["id"] == ratom_message.pk
+
+
+def test_search_account_does_not_exist(url, api_client, ratom_message):
+    response = api_client.get(url, data={"account": 1000})
+    assert len(response.data["results"]) == 0

--- a/api/tests/search/test_search.py
+++ b/api/tests/search/test_search.py
@@ -24,7 +24,7 @@ def test_label_match_single_term(url, api_client, sally1, event):
     sally1.audit.labels.add(event)
     sally1.save()
     response = api_client.get(url, data={"labels_importer": event.name})
-    assert event.name in response.data["results"][0]["labels"]["importer"]
+    assert event.name in response.data["results"][0]["audit"]["labels"][0]["name"]
 
 
 def test_label_match_excludes_others(url, api_client, sally1, sally2, event, org):
@@ -33,8 +33,8 @@ def test_label_match_excludes_others(url, api_client, sally1, sally2, event, org
     sally1.save()
     sally2.save()
     response = api_client.get(url, data={"labels_importer": event.name})
-    assert event.name in response.data["results"][0]["labels"]["importer"]
-    assert org.name not in response.data["results"][0]["labels"]["importer"]
+    assert event.name in response.data["results"][0]["audit"]["labels"][0]["name"]
+    assert org.name not in response.data["results"][0]["audit"]["labels"][0]["name"]
 
 
 def test_label_match__or(url, api_client, sally1, sally2, sally3, event, org, date):

--- a/api/tests/test_serializers.py
+++ b/api/tests/test_serializers.py
@@ -16,6 +16,7 @@ def test_serializer_expected_fields(ratom_message_audit):
         "is_record",
         "date_processed",
         "is_restricted",
+        "labels",
         "needs_redaction",
         "restricted_until",
         "updated_by",

--- a/api/views/message.py
+++ b/api/views/message.py
@@ -110,7 +110,7 @@ class MessageDocumentView(LoggingDocumentViewSet):
     }
 
     nested_filter_fields = {
-        "labels_importer": {"field": "labels.importer.raw", "path": "labels"},
+        "labels_importer": {"field": "audit.labels.name.raw", "path": "audit.labels"},
     }
 
     highlight_fields = {

--- a/api/views/message.py
+++ b/api/views/message.py
@@ -1,4 +1,4 @@
-from django_elasticsearch_dsl_drf import constants, filter_backends
+from django_elasticsearch_dsl_drf import filter_backends
 from django_elasticsearch_dsl_drf.pagination import LimitOffsetPagination
 from elasticsearch_dsl import DateHistogramFacet, TermsFacet
 from rest_framework import status
@@ -70,6 +70,7 @@ class MessageDocumentView(LoggingDocumentViewSet):
         filter_backends.FacetedSearchFilterBackend,
         filter_backends.HighlightBackend,
         filter_backends.SimpleQueryStringSearchFilterBackend,
+        filter_backends.NestedFilteringFilterBackend,
     ]
 
     # Define search fields
@@ -106,16 +107,10 @@ class MessageDocumentView(LoggingDocumentViewSet):
         "email": "msg_to",
         "body": "body",
         "processed": "audit.processed",
-        "labels": {
-            "field": "labels",
-            "lookups": [
-                constants.LOOKUP_FILTER_TERMS,
-                constants.LOOKUP_FILTER_PREFIX,
-                constants.LOOKUP_FILTER_WILDCARD,
-                constants.LOOKUP_QUERY_IN,
-                constants.LOOKUP_QUERY_EXCLUDE,
-            ],
-        },
+    }
+
+    nested_filter_fields = {
+        "labels_importer": {"field": "labels.importer.raw", "path": "labels"},
     }
 
     highlight_fields = {

--- a/conftest.py
+++ b/conftest.py
@@ -5,17 +5,23 @@ from core.tests import factories
 
 
 @pytest.fixture(scope="function", autouse=True)
-def mock_es_registry():
+def mock_es_registry(request):
     """Fixture to mock ES registry and use it automatically in every test."""
-    with mock.patch("django_elasticsearch_dsl.signals.registry") as mock_registry:
-        yield mock_registry
+    if "elasticsearch" not in request.fixturenames:
+        with mock.patch("django_elasticsearch_dsl.signals.registry") as mock_registry:
+            yield mock_registry
+    else:
+        yield None
 
 
 @pytest.fixture(scope="function", autouse=True)
-def mock_core_registry():
+def mock_core_registry(request):
     """Fixture to mock ES registry from core.signals and use it automatically in every test."""
-    with mock.patch("core.signals.registry") as mock_core_registry:
-        yield mock_core_registry
+    if "elasticsearch" not in request.fixturenames:
+        with mock.patch("core.signals.registry") as mock_core_registry:
+            yield mock_core_registry
+    else:
+        yield None
 
 
 @pytest.fixture

--- a/core/models.py
+++ b/core/models.py
@@ -177,9 +177,7 @@ class MessageAudit(models.Model):
         of labels that we will have are Static and Importer
         :return:
         """
-        return {
-            "importer": [x.name for x in self.labels.all()],
-        }
+        return list(self.labels.values("type", "name"))
 
 
 class Message(models.Model):
@@ -216,6 +214,7 @@ class Message(models.Model):
                 "processed": self.audit.processed,
                 "is_record": self.audit.is_record,
                 "date_processed": self.audit.date_processed,
+                "labels": self.audit.labels_indexing,
             }
         )
 
@@ -235,7 +234,7 @@ class Message(models.Model):
 
     @property
     def labels_indexing(self):
-        return dict_to_obj(self.audit.labels_indexing)
+        return self.audit.labels_indexing
 
     def __str__(self):
         return f"{self.subject[:40]}..."

--- a/core/models.py
+++ b/core/models.py
@@ -170,6 +170,21 @@ class MessageAudit(models.Model):
     updated_by = models.ForeignKey(User, null=True, on_delete=models.PROTECT)
     history = HistoricalRecords()
 
+    def get_labels(self):
+        """
+        Compiles the various labels and returns them as a dict. For the moment the only type
+        of labels that we will have are Static and Importer
+        :return:
+        """
+        static_labels = [
+            {"value": x.attname}
+            for x in self._meta.fields
+            if getattr(self, x.attname) is True
+        ]
+        importer_labels = [{"value": x.name} for x in self.labels.all()]
+        label_dict = {"labels": {"static": static_labels, "importer": importer_labels,}}
+        return label_dict
+
 
 class Message(models.Model):
     """A model to store individual email messages.

--- a/core/models.py
+++ b/core/models.py
@@ -235,7 +235,6 @@ class Message(models.Model):
 
     @property
     def labels_indexing(self):
-        print(self.audit.labels_indexing)
         return dict_to_obj(self.audit.labels_indexing)
 
     def __str__(self):

--- a/core/models.py
+++ b/core/models.py
@@ -170,6 +170,17 @@ class MessageAudit(models.Model):
     updated_by = models.ForeignKey(User, null=True, on_delete=models.PROTECT)
     history = HistoricalRecords()
 
+    @property
+    def labels_indexing(self):
+        """
+        Compiles the various labels and returns them as a dict. For the moment the only type
+        of labels that we will have are Static and Importer
+        :return:
+        """
+        return {
+            "importer": [{"name": x.name} for x in self.labels.all()],
+        }
+
 
 class Message(models.Model):
     """A model to store individual email messages.
@@ -224,7 +235,8 @@ class Message(models.Model):
 
     @property
     def labels_indexing(self):
-        return list(self.audit.labels.values_list("name", flat=True))
+        print(self.audit.labels_indexing)
+        return dict_to_obj(self.audit.labels_indexing)
 
     def __str__(self):
         return f"{self.subject[:40]}..."

--- a/core/models.py
+++ b/core/models.py
@@ -178,7 +178,7 @@ class MessageAudit(models.Model):
         :return:
         """
         return {
-            "importer": [{"name": x.name} for x in self.labels.all()],
+            "importer": [x.name for x in self.labels.all()],
         }
 
 

--- a/core/models.py
+++ b/core/models.py
@@ -170,21 +170,6 @@ class MessageAudit(models.Model):
     updated_by = models.ForeignKey(User, null=True, on_delete=models.PROTECT)
     history = HistoricalRecords()
 
-    def get_labels(self):
-        """
-        Compiles the various labels and returns them as a dict. For the moment the only type
-        of labels that we will have are Static and Importer
-        :return:
-        """
-        static_labels = [
-            {"value": x.attname}
-            for x in self._meta.fields
-            if getattr(self, x.attname) is True
-        ]
-        importer_labels = [{"value": x.name} for x in self.labels.all()]
-        label_dict = {"labels": {"static": static_labels, "importer": importer_labels,}}
-        return label_dict
-
 
 class Message(models.Model):
     """A model to store individual email messages.

--- a/core/tests/factories.py
+++ b/core/tests/factories.py
@@ -75,3 +75,11 @@ class MessageFactory(factory.DjangoModelFactory):
             obj.file = kwargs["file"]
         obj.save()
         return obj
+
+
+class LabelFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = core.Label
+
+    name = factory.Faker("State")
+    type = core.Label.IMPORTER

--- a/etl/importer.py
+++ b/etl/importer.py
@@ -1,14 +1,13 @@
 import logging
 from typing import List
 from django.conf import settings
-from libratom.lib.entities import load_spacy_model
 from spacy.language import Language
 from tqdm import tqdm
 import pypff
 
 from core import models as ratom
 from etl.message.forms import ArchiveMessageForm
-from etl.message.nlp import extract_labels
+from etl.message.nlp import extract_labels, load_nlp_model
 from etl.providers.base import ImportProvider, ImportProviderError
 from etl.providers.factory import import_provider_factory, ProviderTypes
 
@@ -197,13 +196,7 @@ def import_psts(
     is_remote=False,
 ) -> None:
     logger.info("Import process started")
-    spacy_model_name = "en_core_web_sm"
-    logger.info(f"Loading {spacy_model_name} spacy model")
-    spacy_model, spacy_model_version = load_spacy_model(spacy_model_name)
-    assert spacy_model
-    logger.info(
-        f"Loaded spacy model: {spacy_model_name}, version: {spacy_model_version}"
-    )
+    spacy_model = load_nlp_model()
     account, _ = ratom.Account.objects.get_or_create(title=account)
     if clean:
         logger.warning(f"Deleting {account.title} account files (if exists)")

--- a/etl/message/nlp.py
+++ b/etl/message/nlp.py
@@ -1,9 +1,18 @@
 import logging
 
+from libratom.lib.entities import load_spacy_model
+
 from core.models import Label
 
 
 logger = logging.getLogger(__name__)
+
+
+def load_nlp_model(model_name="en_core_web_sm"):
+    logger.info(f"Loading {model_name} spacy model")
+    spacy_model, spacy_model_version = load_spacy_model(model_name)
+    logger.info(f"Loaded spacy model: {model_name}, version: {spacy_model_version}")
+    return spacy_model
 
 
 def extract_labels(text, spacy_model):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = ratom.settings.local
+DJANGO_SETTINGS_MODULE = ratom.settings.test
 addopts = --reuse-db --cov=api --cov=etl --cov=core --cov-report=html --cov-report=term -vvv

--- a/ratom/settings/test.py
+++ b/ratom/settings/test.py
@@ -1,0 +1,5 @@
+from ratom.settings.dev import *  # noqa
+
+ELASTICSEARCH_INDEX_NAMES = {
+    "api.documents.message": "test_message",
+}


### PR DESCRIPTION
Summary:
* Move labels to audit serializer
* Add Elasticsearch tests stub with initial label tests (currently disabled on CI)
    * Test locally with ``TEST_ELASTICSEARCH=true pytest``
* Enabled nested filtering on audit.label.name in message search view, required for RATOM-86
* Move spacy model loading to etl.message.nlp module
* Add NLP tagging to sample data

Requires re-indexing. Easiest to test with sample data:

```
python manage.py search_index --delete && python manage.py search_index --create
python manage.py reset_sample_data
```