### PR TITLE
[RATOM-134] add arbitrary labels

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -135,7 +135,6 @@ class MessageAuditSerializer(serializers.ModelSerializer):
             "labels",
         ]
         read_only_fields = ["processed", "date_processed", "updated_by"]
-        validators = [serializers.UniqueTogetherValidator]
 
 
 class MessageSerializer(serializers.ModelSerializer):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -85,7 +85,7 @@ class LabelSerializer(serializers.ModelSerializer):
 
 
 class MessageAuditSerializer(serializers.ModelSerializer):
-    labels = LabelSerializer(many=True)
+    labels = LabelSerializer(many=True, required=False)
 
     def validate(self, data):
         is_record = data.get("is_record")

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -78,8 +78,14 @@ class AccountSerializer(serializers.ModelSerializer):
         }
 
 
+class LabelSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Label
+        fields = "__all__"
+
+
 class MessageAuditSerializer(serializers.ModelSerializer):
-    labels = serializers.SerializerMethodField()
+    labels = LabelSerializer(many=True)
 
     def validate(self, data):
         is_record = data.get("is_record")
@@ -106,6 +112,10 @@ class MessageAuditSerializer(serializers.ModelSerializer):
             instance.is_restricted = validated_data["is_restricted"]
         if "needs_redaction" in validated_data:
             instance.needs_redaction = validated_data["needs_redaction"]
+        # if "labels" in validated_data:
+        #     for label in validated_data["labels"]:
+        #         l = Label.objects.get_or_create(**label)
+        #         instance.labels.add(l)
         instance.save()
         return instance
 
@@ -125,6 +135,7 @@ class MessageAuditSerializer(serializers.ModelSerializer):
             "labels",
         ]
         read_only_fields = ["processed", "date_processed", "updated_by"]
+        validators = [serializers.UniqueTogetherValidator]
 
 
 class MessageSerializer(serializers.ModelSerializer):

--- a/api/views/message.py
+++ b/api/views/message.py
@@ -38,13 +38,13 @@ def message_detail(request, pk):
         """
         We don't really edit messages-- this endpoint updates an associated MessageAudit
         """
-        if "labels" in request.data:
-            for label in request.data["labels"]:
-                (lb, _) = Label.objects.get_or_create(**label)
-                if lb not in message.audit.labels.all():
-                    message.audit.labels.add(lb)
-                    message.audit.save()
-            message.save()
+        if "label" in request.data:
+            label = request.data["label"]
+            lb, _ = Label.objects.get_or_create(**label)
+            if lb not in message.audit.labels.all():
+                message.audit.labels.add(lb)
+                message.audit.save()
+                message.save()
             serialized_message = MessageSerializer(message)
             return Response(serialized_message.data, status=status.HTTP_201_CREATED)
         else:

--- a/api/views/message.py
+++ b/api/views/message.py
@@ -42,7 +42,6 @@ def message_detail(request, pk):
             for label in request.data["labels"]:
                 (lb, _) = Label.objects.get_or_create(**label)
                 if lb not in message.audit.labels.all():
-                    # import pdb; pdb.set_trace()
                     message.audit.labels.add(lb)
                     message.audit.save()
             message.save()

--- a/api/views/message.py
+++ b/api/views/message.py
@@ -14,7 +14,7 @@ from api.serializers import (
 )
 from api.views.utils import LoggingDocumentViewSet
 from api.filter_backends import CustomFilteringFilterBackend
-from core.models import Message
+from core.models import Message, Label
 
 __all__ = ("message_detail", "MessageDocumentView")
 
@@ -38,11 +38,25 @@ def message_detail(request, pk):
         """
         We don't really edit messages-- this endpoint updates an associated MessageAudit
         """
-        serialized_audit = MessageAuditSerializer(message.audit, data=request.data)
-        if serialized_audit.is_valid():
-            serialized_audit.save(updated_by=request.user)
-            return Response(serialized_audit.data, status=status.HTTP_201_CREATED)
-        return Response(serialized_audit.errors, status=status.HTTP_400_BAD_REQUEST)
+        if "labels" in request.data:
+            for label in request.data["labels"]:
+                (lb, _) = Label.objects.get_or_create(**label)
+                if lb not in message.audit.labels.all():
+                    # import pdb; pdb.set_trace()
+                    message.audit.labels.add(lb)
+                    message.audit.save()
+            message.save()
+            serialized_message = MessageSerializer(message)
+            return Response(serialized_message.data, status=status.HTTP_201_CREATED)
+        else:
+            serialized_audit = MessageAuditSerializer(
+                message.audit, data=request.data, partial=True
+            )
+            if serialized_audit.is_valid():
+                serialized_audit.save(updated_by=request.user)
+                serialized_message = MessageSerializer(message)
+                return Response(serialized_message.data, status=status.HTTP_201_CREATED)
+            return Response(serialized_audit.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
 HIGHLIGHT_LABELS = {


### PR DESCRIPTION
forked the PUT handler on message_detail view to handle adding labels.
The UniqueTogether constraint on the label model resulted in some interesting problems during validation, as mentioned [in this medium article](https://medium.com/django-rest-framework/dealing-with-unique-constraints-in-nested-serializers-dade33b831d9). Instead of overriding all of the validators and possibly losing some desired functionality, we've simple performed the get_or_create in the view.

Tested with integration testing on the front end.