### PR TITLE
[RATOM-204] Adds endpoint and custom response.

### DIFF
--- a/api/documents/message.py
+++ b/api/documents/message.py
@@ -58,5 +58,7 @@ class MessageDocument(Document):
         },
     )
 
+    file = fields.ObjectField(properties={"filename": fields.StringField()},)
+
     class Django(object):
         model = Message

--- a/api/management/commands/add_sample_file.py
+++ b/api/management/commands/add_sample_file.py
@@ -1,0 +1,10 @@
+from django.core.management.base import BaseCommand
+
+from api.sample_data.data import sample_add_additional
+
+
+class Command(BaseCommand):
+    help = "Reset sample data"
+
+    def handle(self, *args, **options):
+        sample_add_additional()

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -172,6 +172,20 @@ class MessageSerializer(serializers.ModelSerializer):
         ]
 
 
+class ExportDocumentSerializer(serializers.Serializer):
+    """Serializer for Export document"""
+
+    source_id = serializers.CharField(read_only=True)
+    file = serializers.CharField(read_only=True)
+
+    class Meta:
+        document = MessageDocument
+        fields = (
+            "source_id",
+            "file",
+        )
+
+
 class MessageDocumentSerializer(serializers.Serializer):
     """Serializer for the Message document."""
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -172,20 +172,6 @@ class MessageSerializer(serializers.ModelSerializer):
         ]
 
 
-class ExportDocumentSerializer(serializers.Serializer):
-    """Serializer for Export document"""
-
-    source_id = serializers.CharField(read_only=True)
-    file = serializers.CharField(read_only=True)
-
-    class Meta:
-        document = MessageDocument
-        fields = (
-            "source_id",
-            "file",
-        )
-
-
 class MessageDocumentSerializer(serializers.Serializer):
     """Serializer for the Message document."""
 

--- a/api/tests/search/conftest.py
+++ b/api/tests/search/conftest.py
@@ -28,6 +28,11 @@ def url():
 
 
 @pytest.fixture
+def export_url():
+    return reverse("export_messages")
+
+
+@pytest.fixture
 def account_eric():
     return factories.AccountFactory()
 

--- a/api/tests/search/test_search.py
+++ b/api/tests/search/test_search.py
@@ -65,6 +65,7 @@ def test_export_match_one_file(export_url, api_client, sally1, eric1, org, event
     resp_data = json.loads(gzip.decompress(response.data))
     assert len(resp_data) == 1
     assert eric1.file.filename in list(resp_data.keys())
+    assert eric1.source_id in list(resp_data.values())[0]
 
 
 def test_export_match_two_file(export_url, api_client, sally1, eric1, org, event):
@@ -79,4 +80,6 @@ def test_export_match_two_file(export_url, api_client, sally1, eric1, org, event
     keys = list(resp_data.keys())
     assert len(resp_data) == 2
     assert eric1.file.filename in keys
+    assert eric1.source_id in list(resp_data.values())[1]
     assert sally1.file.filename in keys
+    assert sally1.source_id in list(resp_data.values())[0]

--- a/api/urls.py
+++ b/api/urls.py
@@ -10,6 +10,7 @@ from .views import (
     MessageDocumentView,
     FileUpdateView,
     reset_sample_data,
+    ExportDocumentView,
 )
 
 # Auth
@@ -38,6 +39,13 @@ urlpatterns += [
         name="search_messages",
     ),
     path("messages/<int:pk>/", message_detail, name="message_detail"),
+]
+
+# Export
+urlpatterns += [
+    path(
+        "export/", ExportDocumentView.as_view({"get": "list"}), name="export_messages",
+    )
 ]
 
 if settings.RATOM_SAMPLE_DATA_ENABLED:

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -2,3 +2,4 @@ from .account import *  # noqa
 from .message import *  # noqa
 from .sample_data import *  # noqa
 from .file import *  # noqa
+from .export import ExportDocumentView  # noqa

--- a/api/views/export.py
+++ b/api/views/export.py
@@ -54,7 +54,7 @@ class ExportDocumentView(MessageDocumentView):
             else:
                 current_file[filename] = [id]
         dataIO = compress_response(current_file)
-        returned_file_name = f"rr-{now().strftime('%Y-%m-%dT%H%M%S')}.gz"
+        returned_file_name = f"rr-{now().strftime('%Y-%m-%dT%H%M%S')}.txt.gz"
         return Response(
             data=dataIO,
             headers={

--- a/api/views/export.py
+++ b/api/views/export.py
@@ -1,6 +1,5 @@
 import gzip
 import json
-import ast
 from collections import defaultdict
 from django.utils.timezone import now
 from rest_framework.response import Response
@@ -18,12 +17,6 @@ class FileRenderer(renderers.BaseRenderer):
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
         return data
-
-
-def decompose_drf_data(od):
-    for export_list in od:
-        v = list(export_list.values())
-        yield v[0], ast.literal_eval(v[1])["filename"]
 
 
 def compress_response(data):

--- a/api/views/export.py
+++ b/api/views/export.py
@@ -39,7 +39,7 @@ class ExportDocumentView(MessageDocumentView):
     }
     """
 
-    authentication_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated]
     serializer_class = ExportDocumentSerializer
     pagination_class = None
     renderer_classes = [FileRenderer]
@@ -54,7 +54,7 @@ class ExportDocumentView(MessageDocumentView):
             else:
                 current_file[filename] = [id]
         dataIO = compress_response(current_file)
-        returned_file_name = f"rr-{now().strftime('%Y-%m-%dT%H%M%S')}.gzip"
+        returned_file_name = f"rr-{now().strftime('%Y-%m-%dT%H%M%S')}.gz"
         return Response(
             data=dataIO,
             headers={

--- a/api/views/export.py
+++ b/api/views/export.py
@@ -6,7 +6,6 @@ from rest_framework.response import Response
 from rest_framework import renderers
 from rest_framework.permissions import IsAuthenticated
 from api.views import MessageDocumentView
-from api.serializers import ExportDocumentSerializer
 
 
 class FileRenderer(renderers.BaseRenderer):
@@ -34,7 +33,6 @@ class ExportDocumentView(MessageDocumentView):
     """
 
     permission_classes = [IsAuthenticated]
-    serializer_class = ExportDocumentSerializer
     pagination_class = None
     renderer_classes = [FileRenderer]
 

--- a/api/views/export.py
+++ b/api/views/export.py
@@ -10,8 +10,8 @@ from api.serializers import ExportDocumentSerializer
 
 
 class FileRenderer(renderers.BaseRenderer):
-    media_type = "application/zip"
-    format = "gz"
+    media_type = "application/x-gzip"
+    format = "gzip"
     charset = None
     render_style = "binary"
 
@@ -54,7 +54,7 @@ class ExportDocumentView(MessageDocumentView):
             else:
                 current_file[filename] = [id]
         dataIO = compress_response(current_file)
-        returned_file_name = f"rr-{now().strftime('%Y-%m-%dT%H%M%S')}.gz"
+        returned_file_name = f"rr-{now().strftime('%Y-%m-%dT%H%M%S')}.gzip"
         return Response(
             data=dataIO,
             headers={

--- a/api/views/export.py
+++ b/api/views/export.py
@@ -1,0 +1,65 @@
+import gzip
+import json
+import ast
+from django.utils.timezone import now
+from rest_framework.response import Response
+from rest_framework import renderers
+
+from api.views import MessageDocumentView
+from api.serializers import ExportDocumentSerializer
+
+
+class FileRenderer(renderers.BaseRenderer):
+    media_type = "application/zip"
+    format = "gz"
+    charset = None
+    render_style = "binary"
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        return data
+
+
+def decompose_drf_data(od):
+    for export_list in od:
+        v = list(export_list.values())
+        yield v[0], ast.literal_eval(v[1])["filename"]
+
+
+def compress_response(data):
+    fo = json.dumps(data).encode("utf-8")
+    return gzip.compress(fo)
+
+
+class ExportDocumentView(MessageDocumentView):
+    """Returns a zipped json file that has this structure:
+
+    {
+        "filename01.pst": [001,002,003,004],
+        "filename02.pst": [005,006,007,008],
+    }
+    """
+
+    serializer_class = ExportDocumentSerializer
+    pagination_class = None
+    renderer_classes = [FileRenderer]
+
+    def dispatch(self, request, *args, **kwargs):
+        returned_file_name = f"rr-{now().strftime('%Y-%m-%dT%H%M%S')}.gz"
+        response = super().dispatch(request, *args, **kwargs)
+        current_file = {}
+        for id, filename in decompose_drf_data(response.data):
+            if filename in current_file.keys():
+                current_file[filename].append(id)
+            else:
+                current_file[filename] = [id]
+        dataIO = compress_response(current_file)
+        new_response = Response(
+            data=dataIO,
+            headers={
+                "Content-Disposition": f"attachment; filename={returned_file_name}"
+            },
+        )
+        new_response.accepted_renderer = FileRenderer()
+        new_response.accepted_media_type = "application/zip"
+        new_response.renderer_context = {}
+        return new_response

--- a/api/views/message.py
+++ b/api/views/message.py
@@ -91,6 +91,21 @@ class MessageDocumentView(LoggingDocumentViewSet):
             "facet": TermsFacet,
             "enabled": True,
         },
+        "is_record": {
+            "field": "audit.is_record",
+            "facet": TermsFacet,
+            "enabled": True,
+        },
+        "is_restricted": {
+            "field": "audit.is_restricted",
+            "facet": TermsFacet,
+            "enabled": True,
+        },
+        "needs_redaction": {
+            "field": "audit.needs_redaction",
+            "facet": TermsFacet,
+            "enabled": True,
+        },
         "labels": {
             # "field": "labels.raw",
             "field": "labels",


### PR DESCRIPTION
Here is what seems to be the basic model for extracting the id's from an elasticsearch query.

This also adds a management command that allows a file to be added to one of the existing sample data accounts.  I added this as we needed a reproducible set of queries that would return more than one file.  This one `localhost:8000/api/v1/export/?account=6&search_simple_query_string=checke&` Should give you a file with two nodes from albert meyers and one from bill rapp.

This is WIP since we have to link up front and back and there may be more work to do with the response.  Also, tests need to be added once this is firmed up.