### PR TITLE
[RATOM-217] Unable to create superadmins in admin

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.db.models import Count
 from django.template.defaultfilters import filesizeformat
+from django.utils.translation import gettext_lazy as _
 from core import models as ratom
 
 admin.site.register(ratom.Account)
@@ -11,27 +12,32 @@ admin.site.register(ratom.Account)
 class CustomUserAdmin(UserAdmin):
     model = ratom.User
     list_display = (
+        "pk",
         "email",
         "is_staff",
         "is_active",
+        "is_superuser",
     )
     list_filter = (
-        "email",
         "is_staff",
         "is_active",
+        "is_superuser",
     )
     fieldsets = (
         (None, {"fields": ("email", "password")}),
-        ("Permissions", {"fields": ("is_staff", "is_active")}),
-    )
-    add_fieldsets = (
         (
-            None,
+            _("Permissions"),
             {
-                "classes": ("wide",),
-                "fields": ("email", "password1", "password2", "is_staff", "is_active"),
+                "fields": (
+                    "is_active",
+                    "is_staff",
+                    "is_superuser",
+                    "groups",
+                    "user_permissions",
+                ),
             },
         ),
+        (_("Important dates"), {"fields": ("last_login", "date_joined")}),
     )
     search_fields = ("email",)
     ordering = ("email",)

--- a/core/admin.py
+++ b/core/admin.py
@@ -39,6 +39,22 @@ class CustomUserAdmin(UserAdmin):
         ),
         (_("Important dates"), {"fields": ("last_login", "date_joined")}),
     )
+    add_fieldsets = (
+        (
+            None,
+            {
+                "classes": ("wide",),
+                "fields": (
+                    "email",
+                    "password1",
+                    "password2",
+                    "is_active",
+                    "is_staff",
+                    "is_superuser",
+                ),
+            },
+        ),
+    )
     search_fields = ("email",)
     ordering = ("email",)
 


### PR DESCRIPTION
* Pulls in ``fieldsets`` from base class, UserAdmin, so that ``is_superuser`` is available
* Also adds ``is_superuser`` to ``list_display`` and ``list_filter``
* Supports both adding users and editing users to manage the ``is_superuser`` flag