### PR TITLE
[RATOM-207] Fixes unregistered bug

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -12,6 +12,13 @@ class AccountAdmin(admin.ModelAdmin):
     actions = None
     list_display = ("title",)
 
+    def render_change_form(
+        self, request, context, add=False, change=False, form_url="", obj=None
+    ):
+        rcf = super().render_change_form(request, context, add, change, form_url, obj)
+        rcf.context_data["has_delete_permission"] = False
+        return rcf
+
 
 @admin.register(ratom.User)
 class CustomUserAdmin(UserAdmin):

--- a/core/admin.py
+++ b/core/admin.py
@@ -12,12 +12,8 @@ class AccountAdmin(admin.ModelAdmin):
     actions = None
     list_display = ("title",)
 
-    def render_change_form(
-        self, request, context, add=False, change=False, form_url="", obj=None
-    ):
-        rcf = super().render_change_form(request, context, add, change, form_url, obj)
-        rcf.context_data["has_delete_permission"] = False
-        return rcf
+    def has_delete_permission(self, request, obj=None):
+        return False
 
 
 @admin.register(ratom.User)

--- a/core/models.py
+++ b/core/models.py
@@ -59,7 +59,7 @@ class Account(models.Model):
         self, str_fmt: str = YMD_HMS, as_string: bool = True
     ) -> tuple:
         """
-        Returns the earliest message date in a collection an
+        Returns the earliest and latest message dates in an account.
         :param str_fmt: Optional stftime formatter when returning strings
         :param as_string: return the dates as string representations,
                           based on a default or supplied format.


### PR DESCRIPTION
I'm not certain that this is what we really want, but it is in the AC so this removes the delete button from the `change_form` for the account admin.  

Note: I think we might as well proceed with this.