### PR TITLE
[RATOM-229] Fixes bulk index error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ docker-compose.kibana.yml
 .envs/
 .idea/
 jgdc.yml
+mytest.ini

--- a/api/documents/message.py
+++ b/api/documents/message.py
@@ -24,8 +24,8 @@ class MessageDocument(Document):
 
     id = fields.IntegerField(attr="id")
     source_id = fields.TextField(fielddata=True)
-    msg_to = fields.StringField(analyzer=lowercase_analyzer)
-    msg_from = fields.StringField(analyzer=lowercase_analyzer)
+    msg_to = fields.StringField()
+    msg_from = fields.StringField()
     subject = fields.TextField(analyzer=html_strip)
     body = fields.TextField(analyzer=html_strip)
     sent_date = fields.DateField()


### PR DESCRIPTION
Fixes the exception and allows indexing by removing the lowercase analyzer.  The standard analyzer does lowercase by default.  Since this is the case I removed the lowercase analyzer from the `msg_from` field as well.

https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-analyzer.html#_definition_5